### PR TITLE
Implement AAA pattern in url_utils_spec (#60)

### DIFF
--- a/tests/utils/url_utils_spec.lua
+++ b/tests/utils/url_utils_spec.lua
@@ -17,60 +17,111 @@ local url_utils = require("spring-initializr.utils.url_utils")
 describe("url_utils", function()
     describe("urlencode", function()
         it("encodes spaces as %20", function()
-            local result = url_utils.urlencode("hello world")
+            -- Arrange
+            local input = "hello world"
+
+            -- Act
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             assert.are.equal("hello%20world", result)
         end)
 
         it("encodes special characters correctly", function()
+            -- Arrange
             -- The actual implementation doesn't encode . (dot)
-            local result = url_utils.urlencode("test@example.com")
+            local input = "test@example.com"
+
+            -- Act
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             assert.are.equal("test%40example.com", result)
         end)
 
         it("preserves alphanumeric characters", function()
-            local result = url_utils.urlencode("abc123XYZ")
+            -- Arrange
+            local input = "abc123XYZ"
+            
+            -- Act 
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             assert.are.equal("abc123XYZ", result)
         end)
 
         it("preserves allowed special characters", function()
+            -- Arrange
             -- The actual implementation preserves: - _ . ~
             -- These are "unreserved" characters per RFC 3986
-            local result = url_utils.urlencode("test-file_name.txt")
+            local input = "test-file_name.txt"
+
+            -- Act
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             assert.are.equal("test-file_name.txt", result)
         end)
 
         it("encodes unicode characters", function()
-            local result = url_utils.urlencode("hello世界")
+            -- Arrange 
+            local input = "hello世界"
+
+            -- Act
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             -- Unicode characters should be percent-encoded
             -- Just verify the result contains % signs (percent encoding)
             assert.is_true(result:find("%%") ~= nil)
         end)
 
         it("handles empty string", function()
-            local result = url_utils.urlencode("")
+            -- Arrange
+            local input = ""
+
+            -- Act
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             assert.are.equal("", result)
         end)
 
         it("encodes forward slash", function()
-            local result = url_utils.urlencode("path/to/file")
+            -- Arrange
+            local input = "path/to/file"
+
+            -- Act
+            local result = url_utils.urlencode(input)
+
+            -- Assert
             assert.are.equal("path%2Fto%2Ffile", result)
         end)
     end)
 
     describe("encode_query", function()
         it("encodes single key-value pair", function()
+            -- Arrange
             local params = { name = "test" }
+
+            -- Act
             local result = url_utils.encode_query(params)
+
+            -- Assert
             assert.are.equal("name=test", result)
         end)
 
         it("encodes multiple key-value pairs", function()
+            -- Arrange
             local params = {
                 type = "maven-project",
                 language = "java",
             }
+
+            -- Act
             local result = url_utils.encode_query(params)
 
+            -- Assert
             -- Order may vary, check both keys are present
             assert.is_true(result:find("type=maven%-project") ~= nil)
             assert.is_true(result:find("language=java") ~= nil)
@@ -78,47 +129,69 @@ describe("url_utils", function()
         end)
 
         it("encodes values with special characters", function()
+            -- Arrange
             local params = {
                 name = "My Project",
                 description = "A test project!",
             }
+
+            -- Act
             local result = url_utils.encode_query(params)
 
+            -- Assert
             -- Check that spaces and special chars are encoded
             assert.is_true(result:find("My%%20Project") ~= nil)
             assert.is_true(result:find("test%%20project%%21") ~= nil)
         end)
 
         it("encodes empty value", function()
+            -- Arrange
             local params = { key = "" }
+
+            -- Act
             local result = url_utils.encode_query(params)
+
+            -- Assert
             assert.are.equal("key=", result)
         end)
 
         it("handles empty params table", function()
+            -- Arrange
             local params = {}
+
+            -- Act
             local result = url_utils.encode_query(params)
+
+            -- Assert
             assert.are.equal("", result)
         end)
 
         it("encodes dependencies list", function()
+            -- Arrange
             local params = {
                 dependencies = "web,data-jpa,security",
             }
+
+            -- Act
             local result = url_utils.encode_query(params)
 
+            -- Assert
             -- Commas are encoded as %2C
             -- Hyphens are NOT encoded (unreserved character)
             assert.are.equal("dependencies=web%2Cdata-jpa%2Csecurity", result)
         end)
 
         it("encodes numeric values", function()
+            -- Arrange
             local params = {
                 javaVersion = "17",
                 port = "8080",
             }
+
+            -- Act
             local result = url_utils.encode_query(params)
 
+            -- Assert
             -- Numbers as strings should be preserved
             assert.is_true(result:find("javaVersion=17") ~= nil)
             assert.is_true(result:find("port=8080") ~= nil)


### PR DESCRIPTION
# Description

Fixed Issue #60 by adding comments and refactoring code to follow conventions of AAA pattern. 
- Most tests already split up components of tests to follow pattern
- Some had to be refactored for consistency. 

## Type of change

- Test file refactoring and comment additions

# How Has This Been Tested?

Ran tests in utils directory by running `nvim` in CLI and running the following command:

```:PlenaryBustedDirectory tests/utils```

Output: 

<img width="1098" height="520" alt="image" src="https://github.com/user-attachments/assets/9cbc0300-4a19-4689-8e34-36a46d7272f2" />

**Configuration**:
* Neovim version (nvim --version): v0.11.5
* Operating system and version: MacOS 26.1

# Checklist:

- [X] My code follows the style guidelines of this project (stylua)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A for this fix)
