### PR TITLE
Prevent `spring-initalizr.nvim` from opening recursively (#52)

### DIFF
--- a/lua/spring-initializr/ui/init.lua
+++ b/lua/spring-initializr/ui/init.lua
@@ -51,6 +51,7 @@ local M = {
             configurationFileFormat = "properties",
         },
         metadata = nil,
+        is_open = false,
     },
 }
 
@@ -105,6 +106,7 @@ end
 ----------------------------------------------------------------------------
 local function activate_ui()
     M.state.layout:mount()
+    M.state.is_open = true
     focus_manager.enable_navigation(M)
     dependencies_display.update_display()
     buffer_utils.setup_close_on_buffer_delete(
@@ -132,9 +134,15 @@ end
 --
 -- Public setup function that initializes the full UI system.
 -- Loads metadata, builds layout, and shows the form.
+-- Prevents recursive opening if UI is already displayed.
 --
 ----------------------------------------------------------------------------
 function M.setup()
+    if M.state.is_open then
+        message_utils.show_warn_message("Spring Initializr is already open")
+        return
+    end
+
     setup_highlights()
 
     metadata.fetch_metadata(function(data, err)
@@ -165,6 +173,7 @@ function M.close()
 
     window_utils.safe_close(M.state.outer_popup and M.state.outer_popup.winid)
     M.state.outer_popup = nil
+    M.state.is_open = false
 
     focus_manager.reset()
 end


### PR DESCRIPTION
# Description

Prevent `spring-initalizr.nvim` from opening recursively.
Added state tracking with an is_open flag to prevent recursive UI initialization.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

**Configuration**:
* Neovim version (nvim --version):0.11.0
* Operating system and version:Linux

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
