### PR TITLE
Don't force insert mode when switching input fields (#24)

### DIFF
--- a/lua/spring-initializr/ui/components/common/inputs/inputs.lua
+++ b/lua/spring-initializr/ui/components/common/inputs/inputs.lua
@@ -127,6 +127,16 @@ end
 
 ----------------------------------------------------------------------------
 --
+-- Exits insert mode, switches back  to normal mode
+--
+----------------------------------------------------------------------------
+
+local function switch_to_normal_mode()
+    vim.cmd("stopinsert")
+end
+
+----------------------------------------------------------------------------
+--
 -- Creates input change and submit handlers that update user selections.
 --
 -- @param  config   table/InputConfig  Containing configuration object with
@@ -141,8 +151,7 @@ local function build_input_handlers(config)
         on_submit = function(value)
             update_selection(config, value)
             show_selection(config, value)
-            -- Return to normal mode after submit
-            vim.cmd("stopinsert")
+            switch_to_normal_mode()
         end,
     }
 end

--- a/lua/spring-initializr/ui/managers/focus_manager.lua
+++ b/lua/spring-initializr/ui/managers/focus_manager.lua
@@ -57,37 +57,26 @@ end
 
 ----------------------------------------------------------------------------
 --
--- Focus a window and ensure normal mode.
---
--- @param winid  number  Window ID to focus
+-- Focus the next component in the focusables list.
+-- Ensures normal mode after switching to prevent auto-insert behavior.
 --
 ----------------------------------------------------------------------------
-local function focus_window(winid)
-    if not winid or not vim.api.nvim_win_is_valid(winid) then
-        return
-    end
-    vim.api.nvim_set_current_win(winid)
+local function focus_next()
+    M.current_focus = (M.current_focus % #M.focusables) + 1
+    vim.api.nvim_set_current_win(window_utils.get_winid(M.focusables[M.current_focus]))
     vim.cmd("stopinsert")
 end
 
 ----------------------------------------------------------------------------
 --
--- Focus the next component in the focusables list.
---
-----------------------------------------------------------------------------
-local function focus_next()
-    M.current_focus = (M.current_focus % #M.focusables) + 1
-    focus_window(window_utils.get_winid(M.focusables[M.current_focus]))
-end
-
-----------------------------------------------------------------------------
---
 -- Focus the previous component in the focusables list.
+-- Ensures normal mode after switching to prevent auto-insert behavior.
 --
 ----------------------------------------------------------------------------
 local function focus_prev()
     M.current_focus = (M.current_focus - 2 + #M.focusables) % #M.focusables + 1
-    focus_window(window_utils.get_winid(M.focusables[M.current_focus]))
+    vim.api.nvim_set_current_win(window_utils.get_winid(M.focusables[M.current_focus]))
+    vim.cmd("stopinsert")
 end
 
 ----------------------------------------------------------------------------
@@ -159,6 +148,21 @@ end
 
 ----------------------------------------------------------------------------
 --
+-- Sets focus to a window and ensures normal mode.
+--
+-- @param winid  number  Window ID to focus
+--
+----------------------------------------------------------------------------
+local function focus_window_in_normal_mode(winid)
+    if not winid or not vim.api.nvim_win_is_valid(winid) then
+        return
+    end
+    vim.api.nvim_set_current_win(winid)
+    vim.cmd("stopinsert")
+end
+
+----------------------------------------------------------------------------
+--
 -- Sets focus to the first registered component in normal mode.
 -- Should be called after all components are registered and mounted.
 --
@@ -166,7 +170,7 @@ end
 function M.focus_first()
     vim.schedule(function()
         local winid = get_first_component_winid()
-        focus_window(winid)
+        focus_window_in_normal_mode(winid)
     end)
 end
 


### PR DESCRIPTION
# Description

Don't force insert mode when switching input fields

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
