### PR TITLE
Ensure the buffer number exists before validation (#121)

### DIFF
--- a/lua/spring-initializr/ui/components/common/inputs/inputs.lua
+++ b/lua/spring-initializr/ui/components/common/inputs/inputs.lua
@@ -224,9 +224,8 @@ local function disable_auto_insert(input_component)
         callback = function()
             -- Use vim.schedule to ensure this runs after any NUI auto-insert
             vim.schedule(function()
-                -- Only stop insert if we're in insert mode and this is from navigation
-                -- Check if the buffer is still valid
-                if vim.api.nvim_buf_is_valid(input_component.bufnr) then
+                -- Check if bufnr exists and is valid before accessing
+                if input_component.bufnr and vim.api.nvim_buf_is_valid(input_component.bufnr) then
                     local mode = vim.api.nvim_get_mode().mode
                     -- If we're in insert mode but the user didn't explicitly enter it,
                     -- switch back to normal mode


### PR DESCRIPTION
# Description

Ensuring the buffer number exists before attempting to validate it, preventing the "Expected Lua number" error when restoring saved configurations.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
