### PR TITLE
 Fix UI resizing when splits are created/closed (#150)

### DIFF
--- a/lua/spring-initializr/ui/init.lua
+++ b/lua/spring-initializr/ui/init.lua
@@ -250,7 +250,7 @@ local function reopen_after_resize(data)
     focus_manager.focus_first()
 
     -- Re-setup resize autocmd
-    M.state.resize_autocmd_id = vim.api.nvim_create_autocmd("VimResized", {
+    M.state.resize_autocmd_id = vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
         callback = function()
             if M.state.is_open and M.state.metadata then
                 local saved_metadata = M.state.metadata
@@ -272,12 +272,12 @@ end
 
 ----------------------------------------------------------------------------
 --
--- Sets up autocmd for VimResized event to handle terminal resize.
+-- Sets up autocmd for VimResized and WinResized events to handle resizing.
 --
 ----------------------------------------------------------------------------
 local function setup_resize_autocmd()
     log.trace("Setting up resize autocmd")
-    M.state.resize_autocmd_id = vim.api.nvim_create_autocmd("VimResized", {
+    M.state.resize_autocmd_id = vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
         callback = function()
             if M.state.is_open and M.state.metadata then
                 local saved_metadata = M.state.metadata


### PR DESCRIPTION
# Description

Added WinResized event listener alongside VimResized to properly detect and handle UI resizing when splits are created/closed. The UI now responds to both terminal resizes and internal window layout changes, preserving form state during the resize operation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
