### PR TITLE
Add keybinding to open Telescope dependency picker (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ vim.keymap.set("n", "<leader>sg", "<CMD>SpringGenerateProject<CR>")
 | `<Tab>`      | Navigate forward between fields         |
 | `<S-Tab>`    | Navigate backward                       |
 | `<Ctrl-r>`   | Reset the form (selections && deps)     |
+| `<Ctrl-b>`   | Open dependency picker                  |
 | `j` / `k`    | Move between radio options              |
 | `j` / `k`    | Move between selected dependencies      |
 | `<CR>`       | Confirm field selection or submit       |

--- a/lua/spring-initializr/ui/init.lua
+++ b/lua/spring-initializr/ui/init.lua
@@ -222,6 +222,19 @@ end
 
 ----------------------------------------------------------------------------
 --
+-- Creates a function to open the dependency picker.
+--
+-- @return function  Function that opens the picker and updates display
+--
+----------------------------------------------------------------------------
+local function create_open_picker_fn()
+    return function()
+        telescope.pick_dependencies({}, dependencies_display.update_display)
+    end
+end
+
+----------------------------------------------------------------------------
+--
 -- Reopens the UI with existing metadata (used for resize).
 --
 -- @param  data  table  Metadata to use
@@ -240,7 +253,8 @@ local function reopen_after_resize(data)
     M.state.layout:mount()
     M.state.is_open = true
 
-    focus_manager.enable_navigation(M.close, M.state.selections)
+    local open_picker_fn = create_open_picker_fn()
+    focus_manager.enable_navigation(M.close, M.state.selections, open_picker_fn)
     dependencies_display.update_display()
     buffer_utils.setup_close_on_buffer_delete(
         focus_manager.focusables,
@@ -307,7 +321,8 @@ local function activate_ui()
     M.state.layout:mount()
     M.state.is_open = true
     log.debug("Enabling navigation")
-    focus_manager.enable_navigation(M.close, M.state.selections)
+    local open_picker_fn = create_open_picker_fn()
+    focus_manager.enable_navigation(M.close, M.state.selections, open_picker_fn)
     log.trace("Updating dependencies display")
     dependencies_display.update_display()
     log.debug("Setting up close-on-buffer-delete")

--- a/lua/spring-initializr/ui/managers/focus_manager.lua
+++ b/lua/spring-initializr/ui/managers/focus_manager.lua
@@ -100,6 +100,20 @@ end
 
 ----------------------------------------------------------------------------
 --
+-- Map dependency picker key to a component.
+--
+-- @param comp            table     Component to map key for
+-- @param open_picker_fn  function  Function to open the picker
+--
+----------------------------------------------------------------------------
+local function map_picker_key(comp, open_picker_fn)
+    comp:map("n", "<C-b>", function()
+        open_picker_fn()
+    end, { noremap = true, nowait = true })
+end
+
+----------------------------------------------------------------------------
+--
 -- Create reset handler that resets form and refreshes dependencies display.
 --
 -- @param selections  table  Selections table to reset
@@ -121,13 +135,14 @@ end
 ----------------------------------------------------------------------------
 --
 -- Enable focus navigation across all registered components and register
--- close and reset keys.
+-- close, reset, and picker keys.
 --
--- @param close_fn    function  Function to close UI
--- @param selections  table     Selections table for reset functionality
+-- @param close_fn        function  Function to close UI
+-- @param selections      table     Selections table for reset functionality
+-- @param open_picker_fn  function  Function to open dependency picker (optional)
 --
 ----------------------------------------------------------------------------
-function M.enable_navigation(close_fn, selections)
+function M.enable_navigation(close_fn, selections, open_picker_fn)
     log.info("Enabling navigation")
     log.fmt_debug("Enabling for %d components", #M.focusables)
     M._selections = selections
@@ -137,6 +152,10 @@ function M.enable_navigation(close_fn, selections)
         map_navigation_keys(comp)
         buffer_manager.register_close_key(comp, close_fn)
         buffer_manager.register_reset_key(comp, reset_fn)
+
+        if open_picker_fn then
+            map_picker_key(comp, open_picker_fn)
+        end
     end
 
     log.trace("Navigation enabled successfully")


### PR DESCRIPTION
# Description

Add keybinding to open Telescope dependency picker from anywhere in the TUI.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
