### PR TITLE
Make UI launch realtive to the editor (#148)

### DIFF
--- a/lua/spring-initializr/ui/layout/layout.lua
+++ b/lua/spring-initializr/ui/layout/layout.lua
@@ -136,6 +136,7 @@ local function create_outer_popup(content_height)
     return Popup({
         border = outer_border(),
         position = outer_position(),
+        relative = "editor",
         size = outer_size(content_height),
         win_options = outer_win_options(),
         focusable = false,


### PR DESCRIPTION
# Description

The issue was fixed by adding relative = "editor" to the outer popup configuration in the create_outer_popup() function in lua/spring-initializr/ui/layout/layout.lua. This makes NUI.nvim position the popup relative to the entire editor window instead of the current split window, ensuring the UI always centers on the full screen regardless of which split it was opened from. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
