### PR TITLE
Add arrow key navigation alongside j/k (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,21 +183,34 @@ vim.keymap.set("n", "<leader>si", "<CMD>SpringInitializr<CR>")
 vim.keymap.set("n", "<leader>sg", "<CMD>SpringGenerateProject<CR>")
 ```
 
-| Keybinding   | Action                                  |
-|--------------|-----------------------------------------|
-| `<leader>si` | Open Spring Initializr TUI              |
-| `<leader>sg` | Generate project to current directory   |
-| `<Tab>`      | Navigate forward between fields         |
-| `<S-Tab>`    | Navigate backward                       |
-| `<Ctrl-r>`   | Reset the form (selections && deps)     |
-| `<Ctrl-b>`   | Open dependency picker                  |
-| `<Ctrl-d>`   | Reset selected dependencies             |
-| `j` / `k`    | Move between radio options              |
-| `j` / `k`    | Move between selected dependencies      |
-| `<CR>`       | Confirm field selection or submit       |
-| `dd`         | Remove selected dependency              |
-| `q`          | Close Spring Initializr TUI             |
+## Keybindings
 
+### Global
+
+| Keybinding   | Action                                |
+|--------------|---------------------------------------|
+| `<leader>si` | Open Spring Initializr TUI            |
+| `<leader>sg` | Generate project to current directory |
+
+### Navigation
+
+| Keybinding     | Action                                |
+|----------------|---------------------------------------|
+| `<Tab>`        | Navigate forward between fields       |
+| `<S-Tab>`      | Navigate backward between fields      |
+| `j` / `<Down>` | Move down in radio options or cards   |
+| `k` / `<Up>`   | Move up in radio options or cards     |
+
+### Actions
+
+| Keybinding | Action                              |
+|------------|-------------------------------------|
+| `<CR>`     | Confirm field selection or submit   |
+| `<Ctrl-r>` | Reset the form (selections & deps)  |
+| `<Ctrl-b>` | Open dependency picker              |
+| `<Ctrl-d>` | Reset selected dependencies         |
+| `dd`       | Remove selected dependency          |
+| `q`        | Close Spring Initializr TUI         |
 
 ## Contributing
 

--- a/lua/spring-initializr/ui/components/common/radios/radios.lua
+++ b/lua/spring-initializr/ui/components/common/radios/radios.lua
@@ -33,6 +33,7 @@
 --
 -- Provides a reusable radio button UI component for selecting options
 -- in a popup. Supports flexible width for responsive layouts.
+-- Supports both j/k and arrow key navigation.
 --
 ----------------------------------------------------------------------------
 
@@ -218,28 +219,34 @@ end
 
 ----------------------------------------------------------------------------
 --
--- Map "j" key to move down handler.
+-- Map "j" and Down arrow keys to move down handler.
 --
 ----------------------------------------------------------------------------
 local function map_down_key(popup, state)
-    popup:map("n", "j", function()
+    local handler = function()
         state.selected[1] = handle_move_down(state.items, state.selected[1])
         state.selections[state.key] = state.items[state.selected[1]].value
         render_all_items(popup, state.items, state.selected[1])
-    end, { nowait = true, noremap = true })
+    end
+
+    popup:map("n", "j", handler, { nowait = true, noremap = true })
+    popup:map("n", "<Down>", handler, { nowait = true, noremap = true })
 end
 
 ----------------------------------------------------------------------------
 --
--- Map "k" key to move up handler.
+-- Map "k" and Up arrow keys to move up handler.
 --
 ----------------------------------------------------------------------------
 local function map_up_key(popup, state)
-    popup:map("n", "k", function()
+    local handler = function()
         state.selected[1] = handle_move_up(state.selected[1])
         state.selections[state.key] = state.items[state.selected[1]].value
         render_all_items(popup, state.items, state.selected[1])
-    end, { nowait = true, noremap = true })
+    end
+
+    popup:map("n", "k", handler, { nowait = true, noremap = true })
+    popup:map("n", "<Up>", handler, { nowait = true, noremap = true })
 end
 
 ----------------------------------------------------------------------------

--- a/lua/spring-initializr/ui/components/dependencies/dependencies_display.lua
+++ b/lua/spring-initializr/ui/components/dependencies/dependencies_display.lua
@@ -33,7 +33,7 @@
 --
 -- Manages the UI elements related to Spring Initializr dependency selection.
 -- Uses card-based view to display selected dependencies with full metadata.
--- Supports card navigation and removal with dd keybinding.
+-- Supports card navigation with j/k and arrow keys, and removal with dd keybinding.
 --
 ----------------------------------------------------------------------------
 
@@ -350,28 +350,32 @@ end
 
 ----------------------------------------------------------------------------
 --
--- Setup keybinding for navigation down (j key).
+-- Setup keybinding for navigation down (j and Down arrow keys).
 --
 -- @param popup  Popup  Dependencies display popup
 --
 ----------------------------------------------------------------------------
 local function setup_navigation_down_key(popup)
-    popup:map("n", "j", function()
+    local handler = function()
         focus_next_card()
-    end, { noremap = true, nowait = true })
+    end
+    popup:map("n", "j", handler, { noremap = true, nowait = true })
+    popup:map("n", "<Down>", handler, { noremap = true, nowait = true })
 end
 
 ----------------------------------------------------------------------------
 --
--- Setup keybinding for navigation up (k key).
+-- Setup keybinding for navigation up (k and Up arrow keys).
 --
 -- @param popup  Popup  Dependencies display popup
 --
 ----------------------------------------------------------------------------
 local function setup_navigation_up_key(popup)
-    popup:map("n", "k", function()
+    local handler = function()
         focus_prev_card()
-    end, { noremap = true, nowait = true })
+    end
+    popup:map("n", "k", handler, { noremap = true, nowait = true })
+    popup:map("n", "<Up>", handler, { noremap = true, nowait = true })
 end
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Adds arrow key navigation alongside existing j/k keys for radio buttons and dependency cards, making the plugin more intuitive for users unfamiliar with Vim conventions while maintaining full backward compatibility.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (stylua)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
