### PR TITLE
Create autocmd manager utility (#167)

### DIFF
--- a/lua/spring-initializr/ui/init.lua
+++ b/lua/spring-initializr/ui/init.lua
@@ -42,6 +42,7 @@ local layout_builder = require("spring-initializr.ui.layout.layout")
 local focus_manager = require("spring-initializr.ui.managers.focus_manager")
 local reset_manager = require("spring-initializr.ui.managers.reset_manager")
 local commands_manager = require("spring-initializr.ui.managers.commands_manager")
+local autocmd_manager = require("spring-initializr.ui.managers.autocmd_manager")
 local highlights = require("spring-initializr.styles.highlights")
 local metadata = require("spring-initializr.metadata.metadata")
 local dependencies_display =
@@ -71,7 +72,6 @@ local M = {
         },
         metadata = nil,
         is_open = false,
-        resize_autocmd_id = nil,
     },
 }
 
@@ -204,7 +204,7 @@ end
 local function close_for_resize()
     log.trace("Closing UI for resize")
 
-    remove_resize_autocmd()
+    autocmd_manager.remove_resize_autocmd()
     commands_manager.unblock_splits()
 
     if M.state.layout then
@@ -374,7 +374,14 @@ local function activate_ui()
     log.trace("Focusing first component")
     focus_manager.focus_first()
     log.trace("Setting up resize handler")
-    setup_resize_autocmd()
+    autocmd_manager.setup_resize_autocmd(function()
+        if not M.state.is_open then
+            return
+        end
+        log.debug("Resize detected, remounting UI")
+        M.close()
+        M.setup()
+    end)
     log.info("UI activated successfully")
 end
 
@@ -437,7 +444,7 @@ end
 function M.close()
     log.info("Closing Spring Initializr UI")
 
-    remove_resize_autocmd()
+    autocmd_manager.remove_resize_autocmd()
     commands_manager.unblock_splits()
 
     if M.state.is_open and config.get_persist_state() then

--- a/lua/spring-initializr/ui/init.lua
+++ b/lua/spring-initializr/ui/init.lua
@@ -185,19 +185,6 @@ end
 
 ----------------------------------------------------------------------------
 --
--- Removes the resize autocmd.
---
-----------------------------------------------------------------------------
-local function remove_resize_autocmd()
-    if M.state.resize_autocmd_id then
-        log.trace("Removing resize autocmd")
-        vim.api.nvim_del_autocmd(M.state.resize_autocmd_id)
-        M.state.resize_autocmd_id = nil
-    end
-end
-
-----------------------------------------------------------------------------
---
 -- Closes UI without saving state (used internally for resize).
 --
 ----------------------------------------------------------------------------
@@ -303,35 +290,6 @@ local function reopen_after_resize(data)
     })
 
     log.info("UI reopened after resize")
-end
-
-----------------------------------------------------------------------------
---
--- Sets up autocmd for VimResized and WinResized events to handle resizing.
---
-----------------------------------------------------------------------------
-local function setup_resize_autocmd()
-    log.trace("Setting up resize autocmd")
-    M.state.resize_autocmd_id = vim.api.nvim_create_autocmd(
-        { events.VIM_RESIZED, events.WIN_RESIZED },
-        {
-            callback = function()
-                if M.state.is_open and M.state.metadata then
-                    local saved_metadata = M.state.metadata
-                    local saved_selections = vim.deepcopy(M.state.selections)
-
-                    close_for_resize()
-
-                    vim.defer_fn(function()
-                        M.state.selections = saved_selections
-                        reopen_after_resize(saved_metadata)
-                    end, 50)
-                end
-            end,
-            desc = "Spring Initializr resize handler",
-        }
-    )
-    log.debug("Resize autocmd created")
 end
 
 ----------------------------------------------------------------------------

--- a/lua/spring-initializr/ui/managers/autocmd_manager.lua
+++ b/lua/spring-initializr/ui/managers/autocmd_manager.lua
@@ -1,0 +1,86 @@
+----------------------------------------------------------------------------
+--
+-- ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗
+-- ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║
+-- ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║
+-- ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║
+-- ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║
+-- ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝
+--
+--
+-- spring-initializr.nvim
+--
+--
+-- Copyright (C) 2025 Josip Keresman
+--
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+----------------------------------------------------------------------------
+
+----------------------------------------------------------------------------
+--
+-- Manages creation and cleanup of UI-related autocmds.
+--
+----------------------------------------------------------------------------
+
+----------------------------------------------------------------------------
+-- Dependencies
+----------------------------------------------------------------------------
+local events = require("spring-initializr.events.events")
+local log = require("spring-initializr.trace.log")
+
+----------------------------------------------------------------------------
+-- Module table
+----------------------------------------------------------------------------
+local M = {
+    state = {
+        resize_autocmd_id = nil,
+    },
+}
+
+----------------------------------------------------------------------------
+--
+-- Set up a VimResized autocmd and return its id.
+--
+-- @param callback  function  Resize callback
+-- @return number            Autocmd id
+--
+----------------------------------------------------------------------------
+function M.setup_resize_autocmd(callback)
+    M.remove_resize_autocmd()
+    M.state.resize_autocmd_id = vim.api.nvim_create_autocmd(events.VIM_RESIZED, {
+        callback = callback,
+    })
+    log.trace("Resize autocmd installed")
+    return M.state.resize_autocmd_id
+end
+
+----------------------------------------------------------------------------
+--
+-- Remove the active resize autocmd if present.
+--
+----------------------------------------------------------------------------
+function M.remove_resize_autocmd()
+    if M.state.resize_autocmd_id then
+        pcall(vim.api.nvim_del_autocmd, M.state.resize_autocmd_id)
+        M.state.resize_autocmd_id = nil
+        log.trace("Resize autocmd removed")
+    end
+end
+
+----------------------------------------------------------------------------
+-- Exports
+----------------------------------------------------------------------------
+return M

--- a/tests/ui/autocmd_manager_spec.lua
+++ b/tests/ui/autocmd_manager_spec.lua
@@ -1,0 +1,81 @@
+----------------------------------------------------------------------------
+--
+-- ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗
+-- ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║
+-- ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║
+-- ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║
+-- ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║
+-- ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝
+--
+--
+-- Unit tests for spring-initializr/ui/managers/autocmd_manager.lua
+--
+----------------------------------------------------------------------------
+
+local autocmd_manager = require("spring-initializr.ui.managers.autocmd_manager")
+local events = require("spring-initializr.events.events")
+
+describe("autocmd_manager", function()
+    local original_create
+    local original_delete
+    local create_calls
+    local delete_calls
+
+    before_each(function()
+        original_create = vim.api.nvim_create_autocmd
+        original_delete = vim.api.nvim_del_autocmd
+        create_calls = {}
+        delete_calls = {}
+        autocmd_manager.state.resize_autocmd_id = nil
+
+        vim.api.nvim_create_autocmd = function(event, opts)
+            table.insert(create_calls, { event = event, opts = opts })
+            return 42 + #create_calls
+        end
+
+        vim.api.nvim_del_autocmd = function(id)
+            table.insert(delete_calls, id)
+        end
+    end)
+
+    after_each(function()
+        vim.api.nvim_create_autocmd = original_create
+        vim.api.nvim_del_autocmd = original_delete
+        autocmd_manager.state.resize_autocmd_id = nil
+    end)
+
+    it("creates a resize autocmd using the VimResized event", function()
+        local callback = function() end
+        local id = autocmd_manager.setup_resize_autocmd(callback)
+
+        assert.are.equal(43, id)
+        assert.are.equal(1, #create_calls)
+        assert.are.equal(events.VIM_RESIZED, create_calls[1].event)
+        assert.are.equal(callback, create_calls[1].opts.callback)
+        assert.are.equal(43, autocmd_manager.state.resize_autocmd_id)
+    end)
+
+    it("replaces an existing resize autocmd before creating a new one", function()
+        autocmd_manager.state.resize_autocmd_id = 99
+
+        autocmd_manager.setup_resize_autocmd(function() end)
+
+        assert.are.same({ 99 }, delete_calls)
+        assert.are.equal(43, autocmd_manager.state.resize_autocmd_id)
+    end)
+
+    it("removes the active resize autocmd", function()
+        autocmd_manager.state.resize_autocmd_id = 77
+
+        autocmd_manager.remove_resize_autocmd()
+
+        assert.are.same({ 77 }, delete_calls)
+        assert.is_nil(autocmd_manager.state.resize_autocmd_id)
+    end)
+
+    it("does nothing when there is no resize autocmd", function()
+        autocmd_manager.remove_resize_autocmd()
+
+        assert.are.equal(0, #delete_calls)
+    end)
+end)


### PR DESCRIPTION
## Summary
- add a dedicated `autocmd_manager.lua` module for UI resize autocmd setup and cleanup
- remove direct resize autocmd management from `ui/init.lua`
- add focused autocmd manager tests and rerun the full suite to verify the refactor

## Testing
### Test suite run
- `tests/ui/autocmd_manager_spec.lua`
  - verifies resize autocmd creation
  - verifies replacing an existing autocmd before creating a new one
  - verifies cleanup of the active autocmd
  - verifies no-op cleanup when no autocmd is registered
- full repository test suite run to confirm the rest of the plugin still works after the refactor

### Result summary
- 127 tests passed
- 0 tests failed
- 0 errors

### Commands
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ui/autocmd_manager_spec.lua" +q`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ui/focus_manager_spec.lua" +q`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests" +q`

Closes #167