### PR TITLE
Clear dependencies from any component

### DIFF
--- a/lua/spring-initializr/ui/components/dependencies/dependencies_display.lua
+++ b/lua/spring-initializr/ui/components/dependencies/dependencies_display.lua
@@ -49,7 +49,6 @@ local picker = require("spring-initializr.telescope.telescope")
 local dependency_card = require("spring-initializr.ui.components.dependencies.dependency_card")
 local icons = require("spring-initializr.ui.icons.icons")
 local events = require("spring-initializr.events.events")
-local log = require("spring-initializr.trace.log")
 
 ----------------------------------------------------------------------------
 -- Module
@@ -233,26 +232,6 @@ local function display_popup_config()
     }
 end
 
-----------------------------------------------------------------------------
---
--- Clear all selected dependencies.
---
-----------------------------------------------------------------------------
-local function clear_all_dependencies()
-    log.info("Clearing all dependencies")
-
-    local reset_manager = require("spring-initializr.ui.managers.reset_manager")
-    reset_manager.reset_dependencies_only()
-
-    M.state.focused_card_index = nil
-
-    M.update_display()
-
-    log.debug("All dependencies cleared")
-end
-
-----------------------------------------------------------------------------
---
 -- Move focus to a specific card index.
 --
 -- @param  card_index  number  1-indexed card index
@@ -391,21 +370,6 @@ local function setup_remove_dependency_key(popup)
     end, { noremap = true, nowait = true })
 end
 
-----------------------------------------------------------------------------
---
--- Setup keybinding for clearing all dependencies (Ctrl-d key).
---
--- @param popup  Popup  Dependencies display popup
---
-----------------------------------------------------------------------------
-local function setup_clear_all_dependencies_key(popup)
-    popup:map("n", "<C-d>", function()
-        clear_all_dependencies()
-    end, { noremap = true, nowait = true })
-end
-
-----------------------------------------------------------------------------
---
 -- Setup card navigation and deletion keybindings.
 --
 -- @param popup  Popup  Dependencies display popup
@@ -415,7 +379,6 @@ local function setup_card_keybindings(popup)
     setup_navigation_down_key(popup)
     setup_navigation_up_key(popup)
     setup_remove_dependency_key(popup)
-    setup_clear_all_dependencies_key(popup)
 end
 
 ----------------------------------------------------------------------------

--- a/lua/spring-initializr/ui/managers/focus_manager.lua
+++ b/lua/spring-initializr/ui/managers/focus_manager.lua
@@ -101,13 +101,15 @@ end
 -- @param comp            table      Component to map keys for
 -- @param close_fn        function   Function to close UI
 -- @param reset_fn        function   Function to reset form
+-- @param clear_fn        function   Function to clear dependencies
 -- @param open_picker_fn  function?  Function to open dependency picker
 --
 ----------------------------------------------------------------------------
-local function register_component_keymaps(comp, close_fn, reset_fn, open_picker_fn)
+local function register_component_keymaps(comp, close_fn, reset_fn, clear_fn, open_picker_fn)
     keymap_manager.register_navigation_keys(comp, focus_next, focus_prev)
     keymap_manager.register_close_key(comp, close_fn)
     keymap_manager.register_reset_key(comp, reset_fn)
+    keymap_manager.register_clear_dependencies_key(comp, clear_fn)
 
     if open_picker_fn then
         keymap_manager.register_picker_key(comp, open_picker_fn)
@@ -136,6 +138,24 @@ end
 
 ----------------------------------------------------------------------------
 --
+-- Create a handler that clears dependencies and refreshes their display.
+--
+-- @return function  Clear dependencies handler
+--
+----------------------------------------------------------------------------
+local function create_clear_dependencies_handler()
+    return function()
+        reset_manager.reset_dependencies_only()
+        -- Lazy require to avoid circular dependency
+        local dependencies_display =
+            require("spring-initializr.ui.components.dependencies.dependencies_display")
+        dependencies_display.state.focused_card_index = nil
+        dependencies_display.update_display()
+    end
+end
+
+----------------------------------------------------------------------------
+--
 -- Enable focus navigation across all registered components and register
 -- close, reset, and picker keys.
 --
@@ -149,9 +169,10 @@ function M.enable_navigation(close_fn, selections, open_picker_fn)
     log.fmt_debug("Enabling for %d components", #M.focusables)
     M._selections = selections
     local reset_fn = create_reset_handler(selections)
+    local clear_fn = create_clear_dependencies_handler()
 
     for _, comp in ipairs(M.focusables) do
-        register_component_keymaps(comp, close_fn, reset_fn, open_picker_fn)
+        register_component_keymaps(comp, close_fn, reset_fn, clear_fn, open_picker_fn)
     end
 
     log.trace("Navigation enabled successfully")

--- a/lua/spring-initializr/ui/managers/keymap_manager.lua
+++ b/lua/spring-initializr/ui/managers/keymap_manager.lua
@@ -106,6 +106,18 @@ end
 
 ----------------------------------------------------------------------------
 --
+-- Register the clear dependencies keybinding on a component.
+--
+-- @param comp      table     Component to map key on
+-- @param clear_fn  function  Clear dependencies callback
+--
+----------------------------------------------------------------------------
+function M.register_clear_dependencies_key(comp, clear_fn)
+    map(comp, "<C-d>", clear_fn)
+end
+
+----------------------------------------------------------------------------
+--
 -- Register the dependency picker keybinding on a component.
 --
 -- @param comp            table     Component to map key on

--- a/tests/ui/focus_manager_spec.lua
+++ b/tests/ui/focus_manager_spec.lua
@@ -9,11 +9,15 @@
 --
 --
 -- Unit tests for spring-initializr/ui/managers/focus_manager.lua
--- Updated to test the new <C-b> keybinding for dependency picker
+-- Covers shared navigation, dependency picker, and dependency reset keybindings.
 --
 ----------------------------------------------------------------------------
 
 local focus_manager = require("spring-initializr.ui.managers.focus_manager")
+local reset_manager = require("spring-initializr.ui.managers.reset_manager")
+
+local DEPENDENCIES_DISPLAY_MODULE =
+    "spring-initializr.ui.components.dependencies.dependencies_display"
 
 describe("focus_manager management", function()
     local original_set_current_win
@@ -21,6 +25,8 @@ describe("focus_manager management", function()
     local mock_components
     local mock_close_fn
     local mock_selections
+    local original_reset_dependencies_only
+    local original_dependencies_display
 
     before_each(function()
         -- Reset focus_manager state
@@ -60,10 +66,15 @@ describe("focus_manager management", function()
             description = "Demo project for Spring Boot",
             packageName = "com.example.demo",
         }
+
+        original_reset_dependencies_only = reset_manager.reset_dependencies_only
+        original_dependencies_display = package.loaded[DEPENDENCIES_DISPLAY_MODULE]
     end)
 
     after_each(function()
         vim.api.nvim_set_current_win = original_set_current_win
+        reset_manager.reset_dependencies_only = original_reset_dependencies_only
+        package.loaded[DEPENDENCIES_DISPLAY_MODULE] = original_dependencies_display
         focus_manager.reset()
     end)
 
@@ -134,8 +145,8 @@ describe("focus_manager management", function()
             -- Act
             focus_manager.enable_navigation(mock_close_fn, mock_selections)
 
-            -- Assert - 4 keys per component: <Tab>, <S-Tab>, q (close), <C-r> (reset)
-            assert.are.equal(8, #map_calls)
+            -- Assert - 5 keys per component: navigation, close, reset, and dependency clear
+            assert.are.equal(10, #map_calls)
             local keys = vim.tbl_map(function(c)
                 return c.key
             end, map_calls)
@@ -143,6 +154,7 @@ describe("focus_manager management", function()
             assert.is_true(vim.tbl_contains(keys, "<S-Tab>"))
             assert.is_true(vim.tbl_contains(keys, "q"))
             assert.is_true(vim.tbl_contains(keys, "<C-r>"))
+            assert.is_true(vim.tbl_contains(keys, "<C-d>"))
         end)
 
         it("registers close key on all components", function()
@@ -179,6 +191,38 @@ describe("focus_manager management", function()
 
             -- Assert
             assert.is_true(reset_key_mapped)
+        end)
+
+        it("clears dependencies and refreshes their display from any component", function()
+            -- Arrange
+            local clear_handler
+            local reset_calls = 0
+            local update_calls = 0
+
+            mock_components[1].map = function(_, _, key, handler)
+                if key == "<C-d>" then
+                    clear_handler = handler
+                end
+            end
+            reset_manager.reset_dependencies_only = function()
+                reset_calls = reset_calls + 1
+            end
+            package.loaded[DEPENDENCIES_DISPLAY_MODULE] = {
+                state = { focused_card_index = 2 },
+                update_display = function()
+                    update_calls = update_calls + 1
+                end,
+            }
+            focus_manager.register_component(mock_components[1])
+
+            -- Act
+            focus_manager.enable_navigation(mock_close_fn, mock_selections)
+            clear_handler()
+
+            -- Assert
+            assert.are.equal(1, reset_calls)
+            assert.are.equal(1, update_calls)
+            assert.is_nil(package.loaded[DEPENDENCIES_DISPLAY_MODULE].state.focused_card_index)
         end)
 
         -- NEW TEST: Verify picker key is mapped when open_picker_fn is provided


### PR DESCRIPTION
## Summary

- register Ctrl-D as a common key on every focusable component
- clear only selected dependencies and refresh the dependency display
- remove the dependency-panel-only duplicate mapping
- cover the global mapping and callback behavior

Closes #84

## Test plan

- full Plenary suite: 128 tests, 0 failures
- focused focus-manager suite: 19 tests, 0 failures
- changed-file StyLua check
- changed-production-file Selene and Luacheck
- git diff check