### PR TITLE
Update CI actions for Node 24 runners

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,21 +13,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Capture rustc version
         id: rustc
         run: echo "version=$(rustc --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,7 @@
 name: format
 
+# cspell:ignore dtolnay
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install luacheck
         run: |

--- a/.github/workflows/selene.yml
+++ b/.github/workflows/selene.yml
@@ -13,21 +13,17 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Capture rustc version
         id: rustc
         run: echo "version=$(rustc --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/selene.yml
+++ b/.github/workflows/selene.yml
@@ -1,5 +1,7 @@
 name: Selene Lint
 
+# cspell:ignore dtolnay
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -13,5 +13,5 @@ jobs:
     name: Check spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: streetsidesoftware/cspell-action@v2
+      - uses: actions/checkout@v5
+      - uses: streetsidesoftware/cspell-action@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install telescope.nvim dependency
         run: |
-          git clone --depth 1 https://github.com/nvim-telescope/telescope.nvim \
+          git clone --depth 1 --branch 0.1.x https://github.com/nvim-telescope/telescope.nvim \
             ~/.local/share/nvim/site/pack/vendor/start/telescope.nvim
 
       - name: Run tests (Plenary/Busted)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Neovim (Latest Stable)
         run: |
@@ -37,4 +37,3 @@ jobs:
         run: |
             nvim --headless -u tests/minimal_init.lua \
             -c "PlenaryBustedDirectory tests --exclude-pattern telescope_integration_spec" +q
-


### PR DESCRIPTION
Closes #207

Updates the JavaScript-based workflow actions to releases that run on Node 24:

- `actions/checkout` v4 to v5
- `actions/cache` v4 to v5
- `streetsidesoftware/cspell-action` v2 to v8

It also replaces the archived Node 12-based `actions-rs/toolchain` action with the maintained composite `dtolnay/rust-toolchain` action. The test-only Telescope dependency is pinned to its 0.1.x compatibility branch because Telescope latest now requires Neovim 0.11, newer than the PPA stable version used by this workflow. All workflow YAML parses successfully.